### PR TITLE
Add player names and turn summaries

### DIFF
--- a/poker_draw_cli/src/player.rs
+++ b/poker_draw_cli/src/player.rs
@@ -11,6 +11,7 @@ pub struct Player {
     pub hand: Option<Hand>,
     pub contributed_this_round: u32,
     pub contributed_total: u32,
+    pub last_action: String,
 }
 
 impl Player {
@@ -24,6 +25,7 @@ impl Player {
             hand: None,
             contributed_this_round: 0,
             contributed_total: 0,
+            last_action: String::new(),
         }
     }
 
@@ -33,6 +35,7 @@ impl Player {
         self.hand = Some(Hand::new());
         self.contributed_this_round = 0;
         self.contributed_total = 0;
+        self.last_action.clear();
     }
 
     pub fn can_act(&self) -> bool {


### PR DESCRIPTION
## Summary
- prompt players for custom names at game setup
- track each player's last action and show it alongside pot and current bet
- clear the screen between turns to keep hands private

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b776d8d4fc83239e7fe65be329a8f4