### PR TITLE
Mask prior action details for each player

### DIFF
--- a/poker_draw_cli/src/game.rs
+++ b/poker_draw_cli/src/game.rs
@@ -318,29 +318,36 @@ impl Game {
                     .iter()
                     .map(|pl| pl.contributed_this_round)
                     .sum::<u32>();
+            let active_players: Vec<String> = self
+                .players
+                .iter()
+                .filter(|p| !p.folded && p.hand.is_some())
+                .map(|p| p.name.clone())
+                .collect();
+            let folded_players: Vec<String> = self
+                .players
+                .iter()
+                .filter(|p| p.folded && p.hand.is_some())
+                .map(|p| {
+                    if p.revealed_on_fold {
+                        let hand_str = p.hand.as_ref().map(|h| h.fmt_inline()).unwrap_or_default();
+                        format!("{} [{}]", p.name, hand_str)
+                    } else {
+                        p.name.clone()
+                    }
+                })
+                .collect();
+            println!("Players still in: {}", active_players.join(", "));
+            if folded_players.is_empty() {
+                println!("Players folded: none");
+            } else {
+                println!("Players folded: {}", folded_players.join(", "));
+            }
             println!("Pot: {}", total_pot);
             println!("Current bet: {}", current_bet);
-            println!("Last actions:");
-            for (i, pl) in self.players.iter().enumerate() {
-                if pl.chips == 0 || i == pid {
-                    continue;
-                }
-                let act = if pl.last_action.is_empty() {
-                    "none"
-                } else {
-                    pl.last_action.as_str()
-                };
-                println!("  {:<10}: {}", pl.name, act);
-            }
-            let hand_str = self.players[pid]
-                .hand
-                .as_ref()
-                .map(|h| h.fmt_inline())
-                .unwrap_or_default();
             println!(
-                "{} to act. Hand: [{}]. Stack: {} chips. You have {} seconds.",
+                "Action on: {}. Stack: {} chips. You have {} seconds.",
                 self.players[pid].name,
-                hand_str,
                 self.players[pid].chips,
                 self.settings.turn_timeout_secs
             );
@@ -350,12 +357,12 @@ impl Game {
             loop {
                 if current_bet == self.players[pid].contributed_this_round {
                     println!(
-                        "Actions: [0] Check  [1] Bet <amt>=min {}  [2] Fold  [3] All-in",
+                        "Actions: [0] Check  [1] Bet <amt>=min {}  [2] Fold  [3] All-in  [4] View cards",
                         self.settings.min_bet
                     );
                 } else {
                     println!(
-                        "Actions: [0] Call {}  [1] Raise <amt>=min {}  [2] Fold  [3] All-in",
+                        "Actions: [0] Call {}  [1] Raise <amt>=min {}  [2] Fold  [3] All-in  [4] View cards",
                         call_diff, self.settings.min_bet
                     );
                 }
@@ -408,13 +415,22 @@ impl Game {
                                 choice = 3;
                                 break;
                             }
-                            _ => println!("Invalid selection."),
+                            4 => {
+                                let hand_str = self.players[pid]
+                                    .hand
+                                    .as_ref()
+                                    .map(|h| h.fmt_inline())
+                                    .unwrap_or_default();
+                                println!("Hand: [{}]", hand_str);
+                                continue;
+                            }
+                            _ => println!("Invalid option."),
                         }
                     } else {
-                        println!("Invalid selection.");
+                        println!("Invalid option.");
                     }
                 } else {
-                    println!("Invalid selection.");
+                    println!("Invalid option.");
                 }
             }
 
@@ -422,6 +438,14 @@ impl Game {
                 self.players[pid].folded = true;
                 self.players[pid].last_action = "folded".to_string();
                 println!("{} folds.", self.players[pid].name);
+                println!("Reveal your cards? [y/N]");
+                let ans = read_line_timeout("> ", 0).unwrap_or_default();
+                if matches!(ans.trim().to_lowercase().as_str(), "y" | "yes") {
+                    self.players[pid].revealed_on_fold = true;
+                    if let Some(h) = self.players[pid].hand.as_ref() {
+                        println!("Folded hand: [{}]", h.fmt_inline());
+                    }
+                }
             } else if choice == 0 && current_bet == self.players[pid].contributed_this_round {
                 self.players[pid].last_action = "checked".to_string();
                 println!("{} checks.", self.players[pid].name);
@@ -475,17 +499,13 @@ impl Game {
                         "Invalid bet. Must be between {} and your chips.",
                         self.settings.min_bet
                     );
-                    self.players[pid].folded = true;
-                    self.players[pid].last_action = "folded".to_string();
-                    println!("{} folds (invalid bet).", self.players[pid].name);
+                    continue;
                 } else if amount < self.settings.min_bet && amount != chips_now {
                     println!(
                         "Invalid bet. Must be at least {} or all-in.",
                         self.settings.min_bet
                     );
-                    self.players[pid].folded = true;
-                    self.players[pid].last_action = "folded".to_string();
-                    println!("{} folds (invalid bet).", self.players[pid].name);
+                    continue;
                 } else {
                     self.players[pid].chips -= amount;
                     self.players[pid].contributed_this_round += amount;
@@ -533,9 +553,7 @@ impl Game {
                     println!("{} calls {}.", self.players[pid].name, to_put);
                 } else if amount < self.settings.min_bet {
                     println!("Invalid raise. Minimum is {}.", self.settings.min_bet);
-                    self.players[pid].folded = true;
-                    self.players[pid].last_action = "folded".to_string();
-                    println!("{} folds (invalid raise).", self.players[pid].name);
+                    continue;
                 } else {
                     self.players[pid].chips -= need;
                     self.players[pid].contributed_this_round += need;
@@ -577,39 +595,79 @@ impl Game {
                 continue;
             }
             clear_screen();
-            let pname = self.players[pid].name.clone();
-            let before = {
-                let h = self.players[pid].hand.as_ref().unwrap();
-                h.fmt_inline()
-            };
-            println!("{}'s hand: [{}]", pname, before);
-            println!(
-                "Enter indices to discard (0-4, space-separated), or 'stand'. Type 'quit' to exit. You have {} seconds.",
-                self.settings.turn_timeout_secs
-            );
-
-            let line = read_line_timeout("> ", self.settings.turn_timeout_secs)
-                .unwrap_or_else(|| "stand".to_string());
-            let s = line.trim().to_lowercase();
-
-            if s == "quit" || s == "exit" {
-                println!("Are you sure you want to quit? [y/N]");
-                let ans = read_line_timeout("> ", 0).unwrap_or_default();
-                if matches!(ans.trim().to_lowercase().as_str(), "y" | "yes") {
-                    process::exit(0);
-                } else {
-                    println!("Continuing game.");
-                    continue; // same player continues to draw choice next loop iteration
-                }
-            }
-
-            if s == "stand" || s.is_empty() {
-                println!("{} stands pat.", pname);
+            let pot_total: u32 = self
+                .players
+                .iter()
+                .map(|p| p.contributed_total)
+                .sum();
+            let active_players: Vec<String> = self
+                .players
+                .iter()
+                .filter(|p| !p.folded && p.hand.is_some())
+                .map(|p| p.name.clone())
+                .collect();
+            let folded_players: Vec<String> = self
+                .players
+                .iter()
+                .filter(|p| p.folded && p.hand.is_some())
+                .map(|p| {
+                    if p.revealed_on_fold {
+                        let hand_str = p.hand.as_ref().map(|h| h.fmt_inline()).unwrap_or_default();
+                        format!("{} [{}]", p.name, hand_str)
+                    } else {
+                        p.name.clone()
+                    }
+                })
+                .collect();
+            println!("Players still in: {}", active_players.join(", "));
+            if folded_players.is_empty() {
+                println!("Players folded: none");
             } else {
+                println!("Players folded: {}", folded_players.join(", "));
+            }
+            println!("Pot: {}", pot_total);
+            println!("Action on: {}", self.players[pid].name);
+            let pname = self.players[pid].name.clone();
+            loop {
+                println!(
+                    "Enter indices to discard (0-4, space-separated), 'stand', or 'view'. Type 'quit' to exit. You have {} seconds.",
+                    self.settings.turn_timeout_secs
+                );
+                let line = read_line_timeout("> ", self.settings.turn_timeout_secs)
+                    .unwrap_or_else(|| "stand".to_string());
+                let s = line.trim().to_lowercase();
+
+                if s == "quit" || s == "exit" {
+                    println!("Are you sure you want to quit? [y/N]");
+                    let ans = read_line_timeout("> ", 0).unwrap_or_default();
+                    if matches!(ans.trim().to_lowercase().as_str(), "y" | "yes") {
+                        process::exit(0);
+                    } else {
+                        println!("Continuing game.");
+                        continue;
+                    }
+                }
+
+                if s == "view" {
+                    if let Some(h) = self.players[pid].hand.as_ref() {
+                        println!("Hand: [{}]", h.fmt_inline());
+                    }
+                    continue;
+                }
+
+                if s == "stand" || s.is_empty() {
+                    println!("{} stands pat.", pname);
+                    break;
+                }
+
                 let mut idxs: Vec<usize> = s
                     .split_whitespace()
                     .filter_map(|t| t.parse::<usize>().ok())
                     .collect();
+                if idxs.is_empty() {
+                    println!("Invalid option.");
+                    continue;
+                }
                 if idxs.len() > self.settings.max_discards {
                     idxs.truncate(self.settings.max_discards);
                 }
@@ -630,7 +688,8 @@ impl Game {
                     let h = self.players[pid].hand.as_ref().unwrap();
                     h.fmt_inline()
                 };
-                println!("{} draws. New hand: [{}]", pname, after);
+                println!("{} discards, new hand: [{}]", pname, after);
+                break;
             }
         }
         clear_screen();

--- a/poker_draw_cli/src/player.rs
+++ b/poker_draw_cli/src/player.rs
@@ -12,6 +12,7 @@ pub struct Player {
     pub contributed_this_round: u32,
     pub contributed_total: u32,
     pub last_action: String,
+    pub revealed_on_fold: bool,
 }
 
 impl Player {
@@ -26,6 +27,7 @@ impl Player {
             contributed_this_round: 0,
             contributed_total: 0,
             last_action: String::new(),
+            revealed_on_fold: false,
         }
     }
 
@@ -36,6 +38,7 @@ impl Player {
         self.contributed_this_round = 0;
         self.contributed_total = 0;
         self.last_action.clear();
+        self.revealed_on_fold = false;
     }
 
     pub fn can_act(&self) -> bool {


### PR DESCRIPTION
## Summary
- Offer a "View cards" option during betting and drawing instead of auto-revealing
- Retry on invalid input rather than auto-folding, with optional card reveal on fold
- Show folded players' revealed hands in status summaries

## Testing
- `cargo test --manifest-path poker_draw_cli/Cargo.toml` *(fails: download of config.json failed: [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68b7a15ebaac8323b057c10cde84f43d