### PR TITLE
Announce deck shuffle, handle player quits, validate raises, auto-fold on timeouts, allow showing cards on fold, and refine action menu

### DIFF
--- a/poker_draw_cli/src/player.rs
+++ b/poker_draw_cli/src/player.rs
@@ -12,7 +12,7 @@ pub struct Player {
     pub contributed_this_round: u32,
     pub contributed_total: u32,
     pub last_action: String,
-    pub revealed_on_fold: bool,
+    pub revealed_on_fold: Vec<usize>,
 }
 
 impl Player {
@@ -27,7 +27,7 @@ impl Player {
             contributed_this_round: 0,
             contributed_total: 0,
             last_action: String::new(),
-            revealed_on_fold: false,
+            revealed_on_fold: Vec::new(),
         }
     }
 
@@ -38,7 +38,7 @@ impl Player {
         self.contributed_this_round = 0;
         self.contributed_total = 0;
         self.last_action.clear();
-        self.revealed_on_fold = false;
+        self.revealed_on_fold.clear();
     }
 
     pub fn can_act(&self) -> bool {


### PR DESCRIPTION
## Summary
- Print dealer shuffling and dealing order each time the deck is shuffled
- Allow players to quit the game with confirmation and redistribute their chips
- Confirm before exiting the program
- End the hand immediately when only one player remains, prompting them to optionally reveal their cards
- Hide raise option when a player can't legally raise to prevent crashes
- Fold players automatically on timeouts without offering a reveal option
- Let players specify card indices to reveal when folding
- Initialize action selection variables and remove unused code to clear compiler warnings
- Start the action menu with a "View hand" option, label forced calls as "Call (all-in)", and move "Quit game" to the last slot

## Testing
- `cargo test`
- `cargo test --manifest-path poker_draw_cli/Cargo.toml` *(fails: failed to download from https://index.crates.io/config.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a97505d4832380ed533fa5fda594