### PR TITLE
Announce deck shuffle, handle player quits, validate raises, auto-fold on timeouts, allow showing cards on fold, and refine menus

### DIFF
--- a/poker_draw_cli/src/game.rs
+++ b/poker_draw_cli/src/game.rs
@@ -105,6 +105,17 @@ impl Game {
             }
         }
 
+        let order = self.seat_order_from(self.next_seat(self.dealer));
+        let names: Vec<String> = order
+            .iter()
+            .map(|&pid| self.players[pid].name.clone())
+            .collect();
+        println!(
+            "{} shuffles and deals one card at a time clockwise around the table to {} x5",
+            self.players[self.dealer].name,
+            names.join(" then ")
+        );
+
         // deal 5 cards to each active player
         for _ in 0..5 {
             for pid in self.seat_order_from(self.next_seat(self.dealer)) {
@@ -136,6 +147,7 @@ impl Game {
                 "{} wins {} chips as all others folded.",
                 self.players[winner].name, pot
             );
+            self.offer_reveal(winner);
             for p in self.players.iter_mut() {
                 p.hand = None;
             }
@@ -164,6 +176,7 @@ impl Game {
                 "{} wins {} chips as all others folded.",
                 self.players[winner].name, pot
             );
+            self.offer_reveal(winner);
             for p in self.players.iter_mut() {
                 p.hand = None;
             }
@@ -258,6 +271,48 @@ impl Game {
         (i + 1) % self.players.len()
     }
 
+    fn offer_reveal(&self, pid: usize) {
+        println!("Reveal your cards? [y/N]");
+        if let Some(ans) = read_line_timeout("> ", self.settings.turn_timeout_secs) {
+            if matches!(ans.trim().to_lowercase().as_str(), "y" | "yes") {
+                if let Some(h) = self.players[pid].hand.as_ref() {
+                    println!("{} reveals [{}]", self.players[pid].name, h.fmt_inline());
+                }
+            }
+        }
+    }
+
+    fn handle_player_quit(&mut self, pid: usize) {
+        let chips = self.players[pid].chips;
+        if chips > 0 {
+            let recipients: Vec<usize> = self
+                .players
+                .iter()
+                .enumerate()
+                .filter(|(i, p)| *i != pid && p.chips > 0)
+                .map(|(i, _)| i)
+                .collect();
+            if !recipients.is_empty() {
+                let share = chips / recipients.len() as u32;
+                let mut rem = chips % recipients.len() as u32;
+                for &i in &recipients {
+                    let extra = if rem > 0 {
+                        rem -= 1;
+                        1
+                    } else {
+                        0
+                    };
+                    self.players[i].chips += share + extra;
+                }
+            }
+        }
+        self.players[pid].chips = 0;
+        self.players[pid].folded = true;
+        self.players[pid].hand = None;
+        self.players[pid].last_action = "quit".to_string();
+        println!("{} leaves the game.", self.players[pid].name);
+    }
+
     fn betting_round(&mut self, title: &str, _deck: &mut Deck) -> u32 {
         println!("--- {} ---", title);
         let mut pot: u32 = 0;
@@ -267,7 +322,6 @@ impl Game {
         }
         let mut current_bet: u32 = 0;
         let mut last_raiser: Option<usize> = None;
-        let min_bet = self.settings.min_bet;
 
         let order = self.seat_order_from(self.next_seat(self.dealer));
         let mut idx = 0usize;
@@ -312,6 +366,17 @@ impl Game {
 
             let call_diff = current_bet.saturating_sub(self.players[pid].contributed_this_round);
 
+            let chips_after_call = self.players[pid].chips.saturating_sub(call_diff);
+            let others_can_call_more = self
+                .players
+                .iter()
+                .enumerate()
+                .filter(|(i, p)| {
+                    order.contains(i) && *i != pid && !p.folded && !p.all_in && p.chips > 0
+                })
+                .any(|(_, p)| p.chips + p.contributed_this_round > current_bet);
+            let can_raise = chips_after_call >= self.settings.min_bet && others_can_call_more;
+
             let total_pot = pot
                 + self
                     .players
@@ -329,8 +394,19 @@ impl Game {
                 .iter()
                 .filter(|p| p.folded && p.hand.is_some())
                 .map(|p| {
-                    if p.revealed_on_fold {
-                        let hand_str = p.hand.as_ref().map(|h| h.fmt_inline()).unwrap_or_default();
+                    if !p.revealed_on_fold.is_empty() {
+                        let hand_str = p
+                            .hand
+                            .as_ref()
+                            .map(|h| {
+                                p.revealed_on_fold
+                                    .iter()
+                                    .filter_map(|&i| h.cards.get(i))
+                                    .map(|c| c.to_string())
+                                    .collect::<Vec<_>>()
+                                    .join(" ")
+                            })
+                            .unwrap_or_default();
                         format!("{} [{}]", p.name, hand_str)
                     } else {
                         p.name.clone()
@@ -347,36 +423,81 @@ impl Game {
             println!("Current bet: {}", current_bet);
             println!(
                 "Action on: {}. Stack: {} chips. You have {} seconds.",
-                self.players[pid].name,
-                self.players[pid].chips,
-                self.settings.turn_timeout_secs
+                self.players[pid].name, self.players[pid].chips, self.settings.turn_timeout_secs
             );
             // numeric action selection with validation
-            let choice: u32;
+            let mut choice: u32 = 0;
             let mut amount: u32 = 0;
+            let mut player_left = false;
+            let mut timed_out: bool;
+            let mut reveal_idxs: Vec<usize> = Vec::new();
             loop {
+                timed_out = false;
+                let mut next_num = 1;
+                let mut call_num = 0;
+                let mut bet_num = 0;
+                let mut fold_num = 0;
+                let mut allin_num: Option<u32> = None;
+                let mut quit_num = 0;
+                let mut opts = vec!["[0] View hand".to_string()];
+
                 if current_bet == self.players[pid].contributed_this_round {
-                    println!(
-                        "Actions: [0] Check  [1] Bet <amt>=min {}  [2] Fold  [3] All-in  [4] View cards",
-                        self.settings.min_bet
-                    );
+                    call_num = next_num;
+                    opts.push(format!("[{}] Check", call_num));
+                    next_num += 1;
+                    if can_raise {
+                        bet_num = next_num;
+                        opts.push(format!("[{}] Bet <amt>=min {}", bet_num, self.settings.min_bet));
+                        next_num += 1;
+                    }
                 } else {
-                    println!(
-                        "Actions: [0] Call {}  [1] Raise <amt>=min {}  [2] Fold  [3] All-in  [4] View cards",
-                        call_diff, self.settings.min_bet
-                    );
+                    call_num = next_num;
+                    let mut call_label = format!("Call {}", call_diff);
+                    if call_diff >= self.players[pid].chips {
+                        call_label = format!("Call {} (all-in)", call_diff);
+                    }
+                    opts.push(format!("[{}] {}", call_num, call_label));
+                    next_num += 1;
+                    if can_raise {
+                        bet_num = next_num;
+                        opts.push(format!("[{}] Raise <amt>=min {}", bet_num, self.settings.min_bet));
+                        next_num += 1;
+                    }
                 }
-                println!("Type action number (and amount if needed). Type 'quit' to exit.");
+
+                fold_num = next_num;
+                opts.push(format!("[{}] Fold", fold_num));
+                next_num += 1;
+
+                if current_bet == self.players[pid].contributed_this_round
+                    || call_diff < self.players[pid].chips
+                {
+                    allin_num = Some(next_num);
+                    opts.push(format!("[{}] All-in", next_num));
+                    next_num += 1;
+                }
+
+                quit_num = next_num;
+                opts.push(format!("[{}] Quit game", quit_num));
+
+                println!("Actions: {}", opts.join("  "));
+                println!("Type action number (and amount if needed). Type 'exit' to quit program.");
                 let prompt = if current_bet == self.players[pid].contributed_this_round {
                     "> ".to_string()
                 } else {
                     format!("(call {} chips) > ", call_diff)
                 };
-                let line =
-                    read_line_timeout(&prompt, self.settings.turn_timeout_secs).unwrap_or_default();
+                let line_opt = read_line_timeout(&prompt, self.settings.turn_timeout_secs);
+                let line = match line_opt {
+                    Some(l) => l,
+                    None => {
+                        timed_out = true;
+                        String::new()
+                    }
+                };
                 let s = line.trim().to_lowercase();
-                if s == "quit" || s == "exit" {
-                    println!("Are you sure you want to quit? [y/N]");
+                if s == "exit" {
+                    println!("Are you sure you want to exit? [y/N]");
                     let ans = read_line_timeout("> ", 0).unwrap_or_default();
                     if matches!(ans.trim().to_lowercase().as_str(), "y" | "yes") {
                         process::exit(0);
@@ -385,46 +506,78 @@ impl Game {
                         continue;
                     }
                 }
-                if s.is_empty() {
-                    choice = 2; // timeout -> fold
+                if timed_out || s.is_empty() {
+                    timed_out = true;
+                    choice = 2;
                     break;
                 }
                 let mut parts = s.split_whitespace();
                 if let Some(cstr) = parts.next() {
                     if let Ok(c) = cstr.parse::<u32>() {
-                        match c {
-                            0 => {
-                                choice = 0;
-                                break;
-                            }
-                            1 => {
-                                if let Some(astr) = parts.next() {
-                                    if let Ok(a) = astr.parse::<u32>() {
-                                        amount = a;
-                                        choice = 1;
-                                        break;
-                                    }
+                        if c == 0 {
+                            let hand_str = self.players[pid]
+                                .hand
+                                .as_ref()
+                                .map(|h| h.fmt_inline())
+                                .unwrap_or_default();
+                            println!("Hand: [{}]", hand_str);
+                            continue;
+                        } else if c == call_num {
+                            choice = 0;
+                            break;
+                        } else if bet_num != 0 && c == bet_num {
+                            if let Some(astr) = parts.next() {
+                                if let Ok(a) = astr.parse::<u32>() {
+                                    amount = a;
+                                    choice = 1;
+                                    break;
                                 }
-                                println!("Need an amount for that action.");
                             }
-                            2 => {
-                                choice = 2;
-                                break;
-                            }
-                            3 => {
+                            println!("Need an amount for that action.");
+                        } else if c == fold_num {
+                            reveal_idxs = parts
+                                .filter_map(|p| p.parse::<usize>().ok())
+                                .filter(|&i| i < 5)
+                                .collect();
+                            reveal_idxs.sort_unstable();
+                            reveal_idxs.dedup();
+                            choice = 2;
+                            break;
+                        } else if let Some(ai) = allin_num {
+                            if c == ai {
                                 choice = 3;
                                 break;
+                            } else if c == quit_num {
+                                println!("Are you sure you want to leave the game? [y/N]");
+                                let ans = read_line_timeout("> ", 0).unwrap_or_default();
+                                if matches!(ans.trim().to_lowercase().as_str(), "y" | "yes") {
+                                    self.handle_player_quit(pid);
+                                    seen_since_raise[pid] = true;
+                                    idx = (idx + 1) % order.len();
+                                    player_left = true;
+                                    break;
+                                } else {
+                                    println!("Continuing game.");
+                                    continue;
+                                }
+                            } else {
+                                println!("Invalid option.");
                             }
-                            4 => {
-                                let hand_str = self.players[pid]
-                                    .hand
-                                    .as_ref()
-                                    .map(|h| h.fmt_inline())
-                                    .unwrap_or_default();
-                                println!("Hand: [{}]", hand_str);
+                        } else if c == quit_num {
+                            println!("Are you sure you want to leave the game? [y/N]");
+                            let ans = read_line_timeout("> ", 0).unwrap_or_default();
+                            if matches!(ans.trim().to_lowercase().as_str(), "y" | "yes") {
+                                self.handle_player_quit(pid);
+                                seen_since_raise[pid] = true;
+                                idx = (idx + 1) % order.len();
+                                player_left = true;
+                                break;
+                            } else {
+                                println!("Continuing game.");
                                 continue;
                             }
-                            _ => println!("Invalid option."),
+                        } else {
+                            println!("Invalid option.");
                         }
                     } else {
                         println!("Invalid option.");
@@ -434,16 +587,32 @@ impl Game {
                 }
             }
 
+            if player_left {
+                continue;
+            }
+
             if choice == 2 {
                 self.players[pid].folded = true;
                 self.players[pid].last_action = "folded".to_string();
-                println!("{} folds.", self.players[pid].name);
-                println!("Reveal your cards? [y/N]");
-                let ans = read_line_timeout("> ", 0).unwrap_or_default();
-                if matches!(ans.trim().to_lowercase().as_str(), "y" | "yes") {
-                    self.players[pid].revealed_on_fold = true;
-                    if let Some(h) = self.players[pid].hand.as_ref() {
-                        println!("Folded hand: [{}]", h.fmt_inline());
+                self.players[pid].revealed_on_fold = reveal_idxs.clone();
+                if timed_out {
+                    println!("{} folds (timeout).", self.players[pid].name);
+                } else {
+                    println!("{} folds.", self.players[pid].name);
+                    if !reveal_idxs.is_empty() {
+                        let hand_str = self.players[pid]
+                            .hand
+                            .as_ref()
+                            .map(|h| {
+                                reveal_idxs
+                                    .iter()
+                                    .filter_map(|&i| h.cards.get(i))
+                                    .map(|c| c.to_string())
+                                    .collect::<Vec<_>>()
+                                    .join(" ")
+                            })
+                            .unwrap_or_default();
+                        println!("Shows: [{}]", hand_str);
                     }
                 }
             } else if choice == 0 && current_bet == self.players[pid].contributed_this_round {
@@ -578,6 +747,16 @@ impl Game {
                 }
             }
 
+            let active_remaining = self
+                .players
+                .iter()
+                .filter(|p| !p.folded && p.hand.is_some())
+                .count();
+            if active_remaining <= 1 {
+                seen_since_raise[pid] = true;
+                break;
+            }
+
             seen_since_raise[pid] = true;
             idx = (idx + 1) % order.len();
         }
@@ -595,11 +774,7 @@ impl Game {
                 continue;
             }
             clear_screen();
-            let pot_total: u32 = self
-                .players
-                .iter()
-                .map(|p| p.contributed_total)
-                .sum();
+            let pot_total: u32 = self.players.iter().map(|p| p.contributed_total).sum();
             let active_players: Vec<String> = self
                 .players
                 .iter()
@@ -611,8 +786,19 @@ impl Game {
                 .iter()
                 .filter(|p| p.folded && p.hand.is_some())
                 .map(|p| {
-                    if p.revealed_on_fold {
-                        let hand_str = p.hand.as_ref().map(|h| h.fmt_inline()).unwrap_or_default();
+                    if !p.revealed_on_fold.is_empty() {
+                        let hand_str = p
+                            .hand
+                            .as_ref()
+                            .map(|h| {
+                                p.revealed_on_fold
+                                    .iter()
+                                    .filter_map(|&i| h.cards.get(i))
+                                    .map(|c| c.to_string())
+                                    .collect::<Vec<_>>()
+                                    .join(" ")
+                            })
+                            .unwrap_or_default();
                         format!("{} [{}]", p.name, hand_str)
                     } else {
                         p.name.clone()
@@ -628,17 +814,26 @@ impl Game {
             println!("Pot: {}", pot_total);
             println!("Action on: {}", self.players[pid].name);
             let pname = self.players[pid].name.clone();
+            let mut player_left = false;
             loop {
                 println!(
-                    "Enter indices to discard (0-4, space-separated), 'stand', or 'view'. Type 'quit' to exit. You have {} seconds.",
+                    "Enter card numbers to discard (1-5, space-separated) or 'stand'. Type 0 to view hand. Type 'quit' to fold and leave game or 'exit' to quit program. You have {} seconds.",
                     self.settings.turn_timeout_secs
                 );
-                let line = read_line_timeout("> ", self.settings.turn_timeout_secs)
-                    .unwrap_or_else(|| "stand".to_string());
+                let line_opt = read_line_timeout("> ", self.settings.turn_timeout_secs);
+                let line = match line_opt {
+                    Some(l) => l,
+                    None => {
+                        self.players[pid].folded = true;
+                        self.players[pid].last_action = "folded".to_string();
+                        println!("{} folds (timeout).", pname);
+                        break;
+                    }
+                };
                 let s = line.trim().to_lowercase();
 
-                if s == "quit" || s == "exit" {
-                    println!("Are you sure you want to quit? [y/N]");
+                if s == "exit" {
+                    println!("Are you sure you want to exit? [y/N]");
                     let ans = read_line_timeout("> ", 0).unwrap_or_default();
                     if matches!(ans.trim().to_lowercase().as_str(), "y" | "yes") {
                         process::exit(0);
@@ -648,7 +843,20 @@ impl Game {
                     }
                 }
 
-                if s == "view" {
+                if s == "quit" {
+                    println!("Are you sure you want to leave the game? [y/N]");
+                    let ans = read_line_timeout("> ", 0).unwrap_or_default();
+                    if matches!(ans.trim().to_lowercase().as_str(), "y" | "yes") {
+                        self.handle_player_quit(pid);
+                        player_left = true;
+                        break;
+                    } else {
+                        println!("Continuing game.");
+                        continue;
+                    }
+                }
+
+                if s == "0" {
                     if let Some(h) = self.players[pid].hand.as_ref() {
                         println!("Hand: [{}]", h.fmt_inline());
                     }
@@ -664,9 +872,14 @@ impl Game {
                     .split_whitespace()
                     .filter_map(|t| t.parse::<usize>().ok())
                     .collect();
-                if idxs.is_empty() {
+                if idxs.is_empty()
+                    || idxs.iter().any(|&i| i == 0 || i > 5)
+                {
                     println!("Invalid option.");
                     continue;
+                }
+                for i in idxs.iter_mut() {
+                    *i -= 1;
                 }
                 if idxs.len() > self.settings.max_discards {
                     idxs.truncate(self.settings.max_discards);
@@ -690,6 +903,9 @@ impl Game {
                 };
                 println!("{} discards, new hand: [{}]", pname, after);
                 break;
+            }
+            if player_left {
+                continue;
             }
         }
         clear_screen();

--- a/poker_draw_cli/src/player.rs
+++ b/poker_draw_cli/src/player.rs
@@ -12,7 +12,7 @@ pub struct Player {
     pub contributed_this_round: u32,
     pub contributed_total: u32,
     pub last_action: String,
-    pub revealed_on_fold: bool,
+    pub revealed_on_fold: Vec<usize>,
 }
 
 impl Player {
@@ -27,7 +27,7 @@ impl Player {
             contributed_this_round: 0,
             contributed_total: 0,
             last_action: String::new(),
-            revealed_on_fold: false,
+            revealed_on_fold: Vec::new(),
         }
     }
 
@@ -38,7 +38,7 @@ impl Player {
         self.contributed_this_round = 0;
         self.contributed_total = 0;
         self.last_action.clear();
-        self.revealed_on_fold = false;
+        self.revealed_on_fold.clear();
     }
 
     pub fn can_act(&self) -> bool {


### PR DESCRIPTION
## Summary
- Print dealer shuffling and dealing order each time the deck is shuffled
- Allow players to quit the game with confirmation and redistribute their chips
- Confirm before exiting the program
- End the hand immediately when only one player remains, prompting them to optionally reveal their cards
- Hide raise option when a player can't legally raise to prevent crashes
- Fold players automatically on timeouts without offering a reveal option
- Let players specify card indices to reveal when folding
- Initialize action selection variables and remove unused code to clear compiler warnings
- Start the action menu with a "View hand" option, label forced calls as "Call (all-in)", and move "Quit game" to the last slot
- Let players enter 0 during the draw phase to view their hand and discard cards using numbers 1-5

## Testing
- `cargo test`
- `cargo test --manifest-path poker_draw_cli/Cargo.toml` *(fails: failed to download from https://index.crates.io/config.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a97505d4832380ed533fa5fda594