### PR TITLE
Reuse previous game settings on replay

### DIFF
--- a/poker_draw_cli/src/game.rs
+++ b/poker_draw_cli/src/game.rs
@@ -7,6 +7,7 @@ use crate::hand;
 use crate::player::Player;
 use crate::timer::read_line_timeout;
 
+#[derive(Copy, Clone)]
 pub struct GameSettings {
     pub num_players: usize,
     pub starting_chips: u32,
@@ -35,10 +36,17 @@ impl Game {
         }
     }
 
-    pub fn setup_players(&mut self) {
+    pub fn setup_players(&mut self, names: Option<&[String]>) {
         self.players.clear();
         for i in 0..self.settings.num_players {
             let mut player = Player::new(i, self.settings.starting_chips);
+            if let Some(list) = names {
+                if let Some(name) = list.get(i) {
+                    player.name = name.clone();
+                    self.players.push(player);
+                    continue;
+                }
+            }
             loop {
                 println!("Enter name for Player {} (max 20 chars):", i + 1);
                 if let Some(line) = read_line_timeout("> ", 0) {
@@ -447,7 +455,10 @@ impl Game {
                     next_num += 1;
                     if can_raise {
                         bet_num = next_num;
-                        opts.push(format!("[{}] Bet <amt>=min {}", bet_num, self.settings.min_bet));
+                        opts.push(format!(
+                            "[{}] Bet <amt>=min {}",
+                            bet_num, self.settings.min_bet
+                        ));
                         next_num += 1;
                     }
                 } else {
@@ -460,7 +471,10 @@ impl Game {
                     next_num += 1;
                     if can_raise {
                         bet_num = next_num;
-                        opts.push(format!("[{}] Raise <amt>=min {}", bet_num, self.settings.min_bet));
+                        opts.push(format!(
+                            "[{}] Raise <amt>=min {}",
+                            bet_num, self.settings.min_bet
+                        ));
                         next_num += 1;
                     }
                 }
@@ -872,9 +886,7 @@ impl Game {
                     .split_whitespace()
                     .filter_map(|t| t.parse::<usize>().ok())
                     .collect();
-                if idxs.is_empty()
-                    || idxs.iter().any(|&i| i == 0 || i > 5)
-                {
+                if idxs.is_empty() || idxs.iter().any(|&i| i == 0 || i > 5) {
                     println!("Invalid option.");
                     continue;
                 }

--- a/poker_draw_cli/src/main.rs
+++ b/poker_draw_cli/src/main.rs
@@ -1,9 +1,9 @@
 mod card;
 mod deck;
+mod game;
 mod hand;
 mod player;
 mod timer;
-mod game;
 
 use game::{Game, GameSettings};
 use timer::read_line_timeout;
@@ -16,7 +16,8 @@ fn prompt_number(prompt: &str, min: u32, max: u32, step: Option<u32>) -> u32 {
         };
         println!("{} [{}..{}{}]:", prompt, min, max, step_str);
 
-        if let Some(line) = read_line_timeout("> ", 0) { // 0 = no timeout for setup
+        if let Some(line) = read_line_timeout("> ", 0) {
+            // 0 = no timeout for setup
             if let Ok(val) = line.trim().parse::<u32>() {
                 if val >= min && val <= max && step.map_or(true, |s| val % s == 0) {
                     return val;
@@ -29,22 +30,28 @@ fn prompt_number(prompt: &str, min: u32, max: u32, step: Option<u32>) -> u32 {
 
 fn main() {
     println!("Five-Card Draw Poker (CLI)");
+    let num_players = prompt_number("Number of players", 2, 6, None);
+    let starting_chips = prompt_number("Starting chips (increments of 10)", 10, 10_000, Some(10));
+    let turn_secs = prompt_number("Turn timer (seconds)", 5, 300, None) as u64;
+
+    let settings = GameSettings {
+        num_players: num_players as usize,
+        starting_chips,
+        min_bet: 10,
+        turn_timeout_secs: turn_secs,
+        max_discards: 3, // common variant
+    };
+
+    let mut player_names: Vec<String> = Vec::new();
 
     loop {
-        let num_players = prompt_number("Number of players", 2, 6, None);
-        let starting_chips = prompt_number("Starting chips (increments of 10)", 10, 10_000, Some(10));
-        let turn_secs = prompt_number("Turn timer (seconds)", 5, 300, None) as u64;
-
-        let settings = GameSettings {
-            num_players: num_players as usize,
-            starting_chips,
-            min_bet: 10,
-            turn_timeout_secs: turn_secs,
-            max_discards: 3, // common variant
-        };
-
         let mut game = Game::new(settings);
-        game.setup_players();
+        if player_names.is_empty() {
+            game.setup_players(None);
+            player_names = game.players.iter().map(|p| p.name.clone()).collect();
+        } else {
+            game.setup_players(Some(&player_names));
+        }
 
         let winner = game.play_until_winner();
         println!("Winner: {}", winner.name);


### PR DESCRIPTION
## Summary
- Keep game settings and player names to automatically start another round
- Allow supplying player names to `setup_players`

## Testing
- `cargo test` *(fails: failed to fetch `rand` dependency)*
- `cargo test --offline` *(fails: no matching package named `rand`)*
- `cargo test` *(root crate; passes 0 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c3e784ec8323ae77e5ae606cb440