### PR TITLE
Prevent crash after players go all-in

### DIFF
--- a/poker_draw_cli/src/game.rs
+++ b/poker_draw_cli/src/game.rs
@@ -396,6 +396,9 @@ impl Game {
         let mut last_raiser: Option<usize> = None;
 
         let order = self.seat_order_from(self.next_seat(self.dealer));
+        if order.is_empty() {
+            return pot;
+        }
         let mut idx = 0usize;
         let mut seen_since_raise: Vec<bool> = vec![false; self.players.len()];
 


### PR DESCRIPTION
## Summary
- avoid panicking in betting_round when all players have no chips

## Testing
- `cargo test`
- `cd poker_draw_cli && cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b8c3631f288323b72ef5d64d9d22fd